### PR TITLE
typos and additional names

### DIFF
--- a/include/usysaliases.h
+++ b/include/usysaliases.h
@@ -81,6 +81,10 @@
 #define	UTSNAME		struct utsname
 #endif
 
+#ifndef	RLIMIT
+#define	RLIMIT		struct rlimit
+#endif
+
 #ifndef	SIGACTION
 #define	SIGACTION	struct sigaction
 #endif
@@ -93,20 +97,28 @@
 #define	SIGVAL		union sigval	
 #endif
 
-#ifndef	RLIMIT
-#define	RLIMIT		struct rlimit
-#endif
-
-#ifndef	DIRENT
-#define	DIRENT		struct dirent
-#endif
-
 #ifndef	USTAT
 #define	USTAT		struct ustat
 #endif
 
 #ifndef	USTATVFS
 #define	USTATVFS	struct ustatvfs
+#endif
+
+#ifndef	DIRENT
+#define	DIRENT		struct dirent
+#endif
+
+#ifndef	FLOCK
+#define	FLOCK		struct flock
+#endif
+
+#ifndef	AIOCB
+#define	AIOCB		struct aiocb
+#endif
+
+#ifndef	IOVCEC
+#define	IOVCEC		struct iovec
 #endif
 
 #ifndef	SOCKADDR
@@ -117,8 +129,9 @@
 #define	MSGHDR		struct msghdr
 #endif
 
-#ifndef	WINSIZE
-#define	WINSIZE		struct winsize
+/* not constant - "Control-Message-Header" */
+#ifndef	CMSGHDR
+#define	CMSGHDR		struct cmsghdr
 #endif
 
 #ifndef	TIMEVAL
@@ -141,45 +154,32 @@
 #define	TIMEB		struct timeb
 #endif
 
-#ifndef	ADDRINFO
-#define	ADDRINFO	struct addrinfo
-#endif
-
-#ifndef	HOSTENT
-#define	HOSTENT		struct hostent
-#endif
-
 #ifndef	TERMIOS
 #define	TERMIOS		struct termios
 #endif
 
-#ifndef	STRBUF
-#define	STRBUF		struct strbuf
+#ifndef	WINSIZE
+#define	WINSIZE		struct winsize
 #endif
 
 #ifndef	POLLFD
 #define	POLLFD		struct pollfd
 #endif
 
+#ifndef	STRBUF
+#define	STRBUF		struct strbuf
+#endif
+
 #ifndef	STRRECVFD
 #define	STRRECVFD	struct strrecvfd
 #endif
 
-#ifndef	IOVCEC
-#define	IOVCEC		struct iovec
+#ifndef	MQATTR
+#define	MQATTR		struct mq_attr		/* for SysV-IPC */
 #endif
 
-#ifndef	MSGIDDS
-#define	MSGIDDS		struct msqid_ds		/* for SysV-IPC */
-#endif
-
-/* not constant - "Control-Message-Header" */
-#ifndef	CMSGHDR
-#define	CMSGHDR		struct cmsghdr
-#endif
-
-#ifndef	FLOCK
-#define	FLOCK		struct flock
+#ifndef	MSQIDDS
+#define	MSQIDDS		struct msqid_ds		/* for SysV-IPC */
 #endif
 
 /* constant versions of above */
@@ -196,7 +196,7 @@
 #define	CSOCKADDR	const struct sockaddr
 #endif
 
-/* C-language library structures */
+/* SYSDB account management structures */
 
 #ifndef	PASSWD
 #define	PASSWD		struct passwd
@@ -216,6 +216,28 @@
 
 #ifndef	USERATTR
 #define	USERATTR	userattr
+#endif
+
+/* SYSDB network related structures */
+
+#ifndef	PROTOENT
+#define	PROTOENT	struct protoent
+#endif
+
+#ifndef	NETENT
+#define	NETENT		struct netent
+#endif
+
+#ifndef	HOSTENT
+#define	HOSTENT		struct hostent
+#endif
+
+#ifndef	SERVENT
+#define	SERVENT		struct servent
+#endif
+
+#ifndef	ADDRINFO
+#define	ADDRINFO	struct addrinfo
 #endif
 
 /* constant versions of above */
@@ -238,24 +260,6 @@
 
 #ifndef	CUSERATTR
 #define	CUSERATTR	const USERATTR
-#endif
-
-/* network related structures */
-
-#ifndef	PROTOENT
-#define	PROTOENT	struct protoent
-#endif
-
-#ifndef	NETENT
-#define	NETENT		struct netent
-#endif
-
-#ifndef	HOSTENT
-#define	HOSTENT		struct hostent
-#endif
-
-#ifndef	SERVENT
-#define	SERVENT		struct servent
 #endif
 
 #ifndef	CPROTOENT

--- a/include/utypealiases.h
+++ b/include/utypealiases.h
@@ -81,6 +81,10 @@
 #define	UTSNAME		struct utsname
 #endif
 
+#ifndef	RLIMIT
+#define	RLIMIT		struct rlimit
+#endif
+
 #ifndef	SIGACTION
 #define	SIGACTION	struct sigaction
 #endif
@@ -93,20 +97,28 @@
 #define	SIGVAL		union sigval	
 #endif
 
-#ifndef	RLIMIT
-#define	RLIMIT		struct rlimit
-#endif
-
-#ifndef	DIRENT
-#define	DIRENT		struct dirent
-#endif
-
 #ifndef	USTAT
 #define	USTAT		struct ustat
 #endif
 
 #ifndef	USTATVFS
 #define	USTATVFS	struct ustatvfs
+#endif
+
+#ifndef	DIRENT
+#define	DIRENT		struct dirent
+#endif
+
+#ifndef	FLOCK
+#define	FLOCK		struct flock
+#endif
+
+#ifndef	AIOCB
+#define	AIOCB		struct aiocb
+#endif
+
+#ifndef	IOVCEC
+#define	IOVCEC		struct iovec
 #endif
 
 #ifndef	SOCKADDR
@@ -117,8 +129,9 @@
 #define	MSGHDR		struct msghdr
 #endif
 
-#ifndef	WINSIZE
-#define	WINSIZE		struct winsize
+/* not constant - "Control-Message-Header" */
+#ifndef	CMSGHDR
+#define	CMSGHDR		struct cmsghdr
 #endif
 
 #ifndef	TIMEVAL
@@ -141,45 +154,32 @@
 #define	TIMEB		struct timeb
 #endif
 
-#ifndef	ADDRINFO
-#define	ADDRINFO	struct addrinfo
-#endif
-
-#ifndef	HOSTENT
-#define	HOSTENT		struct hostent
-#endif
-
 #ifndef	TERMIOS
 #define	TERMIOS		struct termios
 #endif
 
-#ifndef	STRBUF
-#define	STRBUF		struct strbuf
+#ifndef	WINSIZE
+#define	WINSIZE		struct winsize
 #endif
 
 #ifndef	POLLFD
 #define	POLLFD		struct pollfd
 #endif
 
+#ifndef	STRBUF
+#define	STRBUF		struct strbuf
+#endif
+
 #ifndef	STRRECVFD
 #define	STRRECVFD	struct strrecvfd
 #endif
 
-#ifndef	IOVCEC
-#define	IOVCEC		struct iovec
+#ifndef	MQATTR
+#define	MQATTR		struct mq_attr		/* for SysV-IPC */
 #endif
 
-#ifndef	MSGIDDS
-#define	MSGIDDS		struct msqid_ds		/* for SysV-IPC */
-#endif
-
-/* not constant - "Control-Message-Header" */
-#ifndef	CMSGHDR
-#define	CMSGHDR		struct cmsghdr
-#endif
-
-#ifndef	FLOCK
-#define	FLOCK		struct flock
+#ifndef	MSQIDDS
+#define	MSQIDDS		struct msqid_ds		/* for SysV-IPC */
 #endif
 
 /* constant versions of above */
@@ -196,7 +196,7 @@
 #define	CSOCKADDR	const struct sockaddr
 #endif
 
-/* C-language library structures */
+/* SYSDB account management structures */
 
 #ifndef	PASSWD
 #define	PASSWD		struct passwd
@@ -216,6 +216,28 @@
 
 #ifndef	USERATTR
 #define	USERATTR	userattr
+#endif
+
+/* SYSDB network related structures */
+
+#ifndef	PROTOENT
+#define	PROTOENT	struct protoent
+#endif
+
+#ifndef	NETENT
+#define	NETENT		struct netent
+#endif
+
+#ifndef	HOSTENT
+#define	HOSTENT		struct hostent
+#endif
+
+#ifndef	SERVENT
+#define	SERVENT		struct servent
+#endif
+
+#ifndef	ADDRINFO
+#define	ADDRINFO	struct addrinfo
 #endif
 
 /* constant versions of above */
@@ -238,24 +260,6 @@
 
 #ifndef	CUSERATTR
 #define	CUSERATTR	const USERATTR
-#endif
-
-/* network related structures */
-
-#ifndef	PROTOENT
-#define	PROTOENT	struct protoent
-#endif
-
-#ifndef	NETENT
-#define	NETENT		struct netent
-#endif
-
-#ifndef	HOSTENT
-#define	HOSTENT		struct hostent
-#endif
-
-#ifndef	SERVENT
-#define	SERVENT		struct servent
 #endif
 
 #ifndef	CPROTOENT

--- a/src/libu/utypealiases.h
+++ b/src/libu/utypealiases.h
@@ -81,6 +81,10 @@
 #define	UTSNAME		struct utsname
 #endif
 
+#ifndef	RLIMIT
+#define	RLIMIT		struct rlimit
+#endif
+
 #ifndef	SIGACTION
 #define	SIGACTION	struct sigaction
 #endif
@@ -93,20 +97,28 @@
 #define	SIGVAL		union sigval	
 #endif
 
-#ifndef	RLIMIT
-#define	RLIMIT		struct rlimit
-#endif
-
-#ifndef	DIRENT
-#define	DIRENT		struct dirent
-#endif
-
 #ifndef	USTAT
 #define	USTAT		struct ustat
 #endif
 
 #ifndef	USTATVFS
 #define	USTATVFS	struct ustatvfs
+#endif
+
+#ifndef	DIRENT
+#define	DIRENT		struct dirent
+#endif
+
+#ifndef	FLOCK
+#define	FLOCK		struct flock
+#endif
+
+#ifndef	AIOCB
+#define	AIOCB		struct aiocb
+#endif
+
+#ifndef	IOVCEC
+#define	IOVCEC		struct iovec
 #endif
 
 #ifndef	SOCKADDR
@@ -117,8 +129,9 @@
 #define	MSGHDR		struct msghdr
 #endif
 
-#ifndef	WINSIZE
-#define	WINSIZE		struct winsize
+/* not constant - "Control-Message-Header" */
+#ifndef	CMSGHDR
+#define	CMSGHDR		struct cmsghdr
 #endif
 
 #ifndef	TIMEVAL
@@ -141,45 +154,32 @@
 #define	TIMEB		struct timeb
 #endif
 
-#ifndef	ADDRINFO
-#define	ADDRINFO	struct addrinfo
-#endif
-
-#ifndef	HOSTENT
-#define	HOSTENT		struct hostent
-#endif
-
 #ifndef	TERMIOS
 #define	TERMIOS		struct termios
 #endif
 
-#ifndef	STRBUF
-#define	STRBUF		struct strbuf
+#ifndef	WINSIZE
+#define	WINSIZE		struct winsize
 #endif
 
 #ifndef	POLLFD
 #define	POLLFD		struct pollfd
 #endif
 
+#ifndef	STRBUF
+#define	STRBUF		struct strbuf
+#endif
+
 #ifndef	STRRECVFD
 #define	STRRECVFD	struct strrecvfd
 #endif
 
-#ifndef	IOVCEC
-#define	IOVCEC		struct iovec
+#ifndef	MQATTR
+#define	MQATTR		struct mq_attr		/* for SysV-IPC */
 #endif
 
-#ifndef	MSGIDDS
-#define	MSGIDDS		struct msqid_ds		/* for SysV-IPC */
-#endif
-
-/* not constant - "Control-Message-Header" */
-#ifndef	CMSGHDR
-#define	CMSGHDR		struct cmsghdr
-#endif
-
-#ifndef	FLOCK
-#define	FLOCK		struct flock
+#ifndef	MSQIDDS
+#define	MSQIDDS		struct msqid_ds		/* for SysV-IPC */
 #endif
 
 /* constant versions of above */
@@ -196,7 +196,7 @@
 #define	CSOCKADDR	const struct sockaddr
 #endif
 
-/* C-language library structures */
+/* SYSDB account management structures */
 
 #ifndef	PASSWD
 #define	PASSWD		struct passwd
@@ -216,6 +216,28 @@
 
 #ifndef	USERATTR
 #define	USERATTR	userattr
+#endif
+
+/* SYSDB network related structures */
+
+#ifndef	PROTOENT
+#define	PROTOENT	struct protoent
+#endif
+
+#ifndef	NETENT
+#define	NETENT		struct netent
+#endif
+
+#ifndef	HOSTENT
+#define	HOSTENT		struct hostent
+#endif
+
+#ifndef	SERVENT
+#define	SERVENT		struct servent
+#endif
+
+#ifndef	ADDRINFO
+#define	ADDRINFO	struct addrinfo
 #endif
 
 /* constant versions of above */
@@ -238,24 +260,6 @@
 
 #ifndef	CUSERATTR
 #define	CUSERATTR	const USERATTR
-#endif
-
-/* network related structures */
-
-#ifndef	PROTOENT
-#define	PROTOENT	struct protoent
-#endif
-
-#ifndef	NETENT
-#define	NETENT		struct netent
-#endif
-
-#ifndef	HOSTENT
-#define	HOSTENT		struct hostent
-#endif
-
-#ifndef	SERVENT
-#define	SERVENT		struct servent
 #endif
 
 #ifndef	CPROTOENT

--- a/src/libuc/hostinfo.cc
+++ b/src/libuc/hostinfo.cc
@@ -374,7 +374,7 @@ int hostinfo_getcanonical(hostinfo *op,cchar **rpp) noex {
 }
 /* end subroutine (hostinfo_getcanonical) */
 
-int hostinfo_curbegin(hostinfo *op,HOSTINFO_CUR *curp) noex {
+int hostinfo_curbegin(hostinfo *op,hostinfo_cur *curp) noex {
 	int		rs ;
 	if ((rs = hostinfo_magic(op,curp)) >= 0) {
 	        curp->i = -1 ;
@@ -383,7 +383,7 @@ int hostinfo_curbegin(hostinfo *op,HOSTINFO_CUR *curp) noex {
 }
 /* end subroutine (hostinfo_curbegin) */
 
-int hostinfo_curend(hostinfo *op,HOSTINFO_CUR *curp) noex {
+int hostinfo_curend(hostinfo *op,hostinfo_cur *curp) noex {
 	int		rs ;
 	if ((rs = hostinfo_magic(op,curp)) >= 0) {
 	        curp->i = -1 ;
@@ -393,11 +393,11 @@ int hostinfo_curend(hostinfo *op,HOSTINFO_CUR *curp) noex {
 /* end subroutine (hostinfo_curend) */
 
 /* enumerate the next hostname */
-int hostinfo_enumname(hostinfo *op,HOSTINFO_CUR *curp,cchar **rpp) noex {
+int hostinfo_enumname(hostinfo *op,hostinfo_cur *curp,cchar **rpp) noex {
 	int		rs ;
 	int		nlen = 0 ;
 	if ((rs = hostinfo_magic(op,curp)) >= 0) {
-	        HOSTINFO_CUR	dcur ;
+	        hostinfo_cur	dcur ;
 	        bool		f_cur = false ;
 	        if (rpp) *rpp = nullptr ;
 	        if (curp == nullptr) {
@@ -456,11 +456,11 @@ int hostinfo_enumname(hostinfo *op,HOSTINFO_CUR *curp,cchar **rpp) noex {
 /* end subroutine (hostinfo_enumname) */
 
 /* enumerate the next host address */
-int hostinfo_enumaddr(hostinfo *op,HOSTINFO_CUR *curp,cuchar **rpp) noex {
+int hostinfo_enumaddr(hostinfo *op,hostinfo_cur *curp,cuchar **rpp) noex {
 	int		rs ;
 	int		alen = 0 ;
 	if ((rs = hostinfo_magic(op,curp)) >= 0) {
-	        HOSTINFO_CUR	dcur ;
+	        hostinfo_cur	dcur ;
 	        bool		f_cur = false ;
 	        if (rpp) *rpp = nullptr ;
 	        if (curp == nullptr) {
@@ -476,7 +476,7 @@ int hostinfo_enumaddr(hostinfo *op,HOSTINFO_CUR *curp,cuchar **rpp) noex {
 	            vog_f	vg = vecobj_get ;
 	            bool	f_exit = false ;
 	            repeat {
-	                int	i ;
+	                int	i = 0 ; /* used afterwards */
 		        void	*vp{} ;
 	                for (i = ci ; (rs = vg(alp,i,&vp)) >= 0 ; i += 1) {
 		            aep = (HOSTINFO_A *) vp ;

--- a/src/libuc/umsg.h
+++ b/src/libuc/umsg.h
@@ -1,8 +1,8 @@
 /* umsg INCLUDE */
 /* lang=C20 */
 
-/* version %I% last-modified %G% */
 /* auxillary operating system support */
+/* version %I% last-modified %G% */
 
 
 /* revision history:
@@ -54,7 +54,7 @@ extern "C" {
 #endif
 
 extern int u_msgget(key_t,int) noex ;
-extern int u_msgctl(int,int,MSGIDDS *) noex ;
+extern int u_msgctl(int,int,MSQIDDS *) noex ;
 extern int u_msgrcv(int,void *,int,sysvmsgtype,int) noex ;
 extern int u_msgsnd(int,void *,int,int) noex ;
 

--- a/src/libuc/utypealiases.h
+++ b/src/libuc/utypealiases.h
@@ -81,6 +81,10 @@
 #define	UTSNAME		struct utsname
 #endif
 
+#ifndef	RLIMIT
+#define	RLIMIT		struct rlimit
+#endif
+
 #ifndef	SIGACTION
 #define	SIGACTION	struct sigaction
 #endif
@@ -93,20 +97,28 @@
 #define	SIGVAL		union sigval	
 #endif
 
-#ifndef	RLIMIT
-#define	RLIMIT		struct rlimit
-#endif
-
-#ifndef	DIRENT
-#define	DIRENT		struct dirent
-#endif
-
 #ifndef	USTAT
 #define	USTAT		struct ustat
 #endif
 
 #ifndef	USTATVFS
 #define	USTATVFS	struct ustatvfs
+#endif
+
+#ifndef	DIRENT
+#define	DIRENT		struct dirent
+#endif
+
+#ifndef	FLOCK
+#define	FLOCK		struct flock
+#endif
+
+#ifndef	AIOCB
+#define	AIOCB		struct aiocb
+#endif
+
+#ifndef	IOVCEC
+#define	IOVCEC		struct iovec
 #endif
 
 #ifndef	SOCKADDR
@@ -117,8 +129,9 @@
 #define	MSGHDR		struct msghdr
 #endif
 
-#ifndef	WINSIZE
-#define	WINSIZE		struct winsize
+/* not constant - "Control-Message-Header" */
+#ifndef	CMSGHDR
+#define	CMSGHDR		struct cmsghdr
 #endif
 
 #ifndef	TIMEVAL
@@ -141,45 +154,32 @@
 #define	TIMEB		struct timeb
 #endif
 
-#ifndef	ADDRINFO
-#define	ADDRINFO	struct addrinfo
-#endif
-
-#ifndef	HOSTENT
-#define	HOSTENT		struct hostent
-#endif
-
 #ifndef	TERMIOS
 #define	TERMIOS		struct termios
 #endif
 
-#ifndef	STRBUF
-#define	STRBUF		struct strbuf
+#ifndef	WINSIZE
+#define	WINSIZE		struct winsize
 #endif
 
 #ifndef	POLLFD
 #define	POLLFD		struct pollfd
 #endif
 
+#ifndef	STRBUF
+#define	STRBUF		struct strbuf
+#endif
+
 #ifndef	STRRECVFD
 #define	STRRECVFD	struct strrecvfd
 #endif
 
-#ifndef	IOVCEC
-#define	IOVCEC		struct iovec
+#ifndef	MQATTR
+#define	MQATTR		struct mq_attr		/* for SysV-IPC */
 #endif
 
-#ifndef	MSGIDDS
-#define	MSGIDDS		struct msqid_ds		/* for SysV-IPC */
-#endif
-
-/* not constant - "Control-Message-Header" */
-#ifndef	CMSGHDR
-#define	CMSGHDR		struct cmsghdr
-#endif
-
-#ifndef	FLOCK
-#define	FLOCK		struct flock
+#ifndef	MSQIDDS
+#define	MSQIDDS		struct msqid_ds		/* for SysV-IPC */
 #endif
 
 /* constant versions of above */
@@ -196,7 +196,7 @@
 #define	CSOCKADDR	const struct sockaddr
 #endif
 
-/* C-language library structures */
+/* SYSDB account management structures */
 
 #ifndef	PASSWD
 #define	PASSWD		struct passwd
@@ -216,6 +216,28 @@
 
 #ifndef	USERATTR
 #define	USERATTR	userattr
+#endif
+
+/* SYSDB network related structures */
+
+#ifndef	PROTOENT
+#define	PROTOENT	struct protoent
+#endif
+
+#ifndef	NETENT
+#define	NETENT		struct netent
+#endif
+
+#ifndef	HOSTENT
+#define	HOSTENT		struct hostent
+#endif
+
+#ifndef	SERVENT
+#define	SERVENT		struct servent
+#endif
+
+#ifndef	ADDRINFO
+#define	ADDRINFO	struct addrinfo
 #endif
 
 /* constant versions of above */
@@ -238,24 +260,6 @@
 
 #ifndef	CUSERATTR
 #define	CUSERATTR	const USERATTR
-#endif
-
-/* network related structures */
-
-#ifndef	PROTOENT
-#define	PROTOENT	struct protoent
-#endif
-
-#ifndef	NETENT
-#define	NETENT		struct netent
-#endif
-
-#ifndef	HOSTENT
-#define	HOSTENT		struct hostent
-#endif
-
-#ifndef	SERVENT
-#define	SERVENT		struct servent
 #endif
 
 #ifndef	CPROTOENT


### PR DESCRIPTION
fixed typos and added some (previously unused) type-aliases
type-alias names were also reordered to lower programmer cognitive load (when verifying)