### PR TITLE
misc changes + greatly simplify |getutmpent|

### DIFF
--- a/include/tmpx.h
+++ b/include/tmpx.h
@@ -1,0 +1,143 @@
+/* tmpx HEADER */
+/* lang=C20 */
+
+/* object to facilitate UTMPX management */
+/* version %I% last-modified %G% */
+
+
+/* revision history:
+
+	= 2000-05-14, David A­D­ Morano
+	Originally written for Rightcore Network Services.
+
+*/
+
+/* Copyright © 2000 David A­D­ Morano.  All rights reserved. */
+
+#ifndef	TMPX_INCLUDE
+#define	TMPX_INCLUDE
+
+
+#include	<envstandards.h>
+#include	<sys/types.h>
+#include	<utmpx.h>
+#include	<usystem.h>
+
+
+/* object defines */
+
+#define	TMPX		struct tmpx_head
+#define	TMPX_CUR	struct tmpx_cursor
+#define	TMPX_FL		struct tmpx_flags
+#define	TMPX_MAGIC	1092387456
+#define	TMPX_ENT	struct utmpx
+#define	TMPX_ENTSIZE	sizeof(TMPX_ENT)
+
+/* other defines */
+
+#if	(defined(OSNAME_SunOS) && (OSNAME_SunOS > 0))
+#define	TMPX_DEFUTMP	"/var/adm/utmpx"
+#elif	defined(OSNAME_Darwin) && (OSNAME_Darwin > 0)
+#define	TMPX_DEFUTMP	"/var/run/utmpx"
+#elif	defined(OSNAME_Linux) && (OSNAME_Linux > 0)
+#else
+#define	TMPX_DEFUTMP	"/var/run/utmpx"
+#endif
+
+/* entry type values */
+
+#define	TMPX_TEMPTY		0	/* entry is unused */
+#define	TMPX_TRUNLEVEL		1
+#define	TMPX_TBOOTTIME		2
+#define	TMPX_TOLDTIME		3
+#define	TMPX_TNEWTIME		4
+#define	TMPX_TPROCINIT		5	/* process spawned by "init" */
+#define	TMPX_TPROCLOGIN		6	/* a "getty" waiting for login */
+#define	TMPX_TPROCUSER		7	/* a regular user process */
+#define	TMPX_TPROCDEAD		8	/* dead process (moved to WTMPX) */
+#define	TMPX_TACCOUNT		9	/* used in WTMPX only? */
+#define	TMPX_TSIGNATURE		10	/* used in WTMPX only? */
+
+/* entry lengths */
+
+#define	TMPX_LID		4
+#define	TMPX_LUSER		32
+#define	TMPX_LLINE		32
+#define	TMPX_LHOST		256
+
+/* UTMPX stuff (in theory could be different from above) */
+
+#ifndef	UTMPX_TEMPTY
+#define	UTMPX_TEMPTY		0	/* entry is unused */
+#define	UTMPX_TRUNLEVEL		1
+#define	UTMPX_TBOOTTIME		2
+#define	UTMPX_TOLDTIME		3
+#define	UTMPX_TNEWTIME		4
+#define	UTMPX_TPROCINIT		5	/* process spawned by "init" */
+#define	UTMPX_TPROCLOGIN	6	/* a "getty" waiting for login */
+#define	UTMPX_TPROCUSER		7	/* a regular user process */
+#define	UTMPX_TPROCDEAD		8	/* used in WTMPX only? */
+#define	UTMPX_TACCOUNT		9	/* used in WTMPX only? */
+#define	UTMPX_TSIGNATURE	10	/* used in WTMPX only? */
+#endif /* UTMPX_TEMPTY */
+
+#ifndef	UTMPX_LID
+#define	UTMPX_LID		4
+#define	UTMPX_LUSER		32
+#define	UTMPX_LLINE		32
+#define	UTMPX_LHOST		256
+#endif
+
+
+struct tmpx_cursor {
+	int		i ;
+} ;
+
+struct tmpx_flags {
+	uint		writable:1 ;
+} ;
+
+struct tmpx_head {
+	cchar		*fname ;	/* stored file name */
+	caddr_t		mapdata ;	/* file mapping buffer */
+	time_t		ti_open ;	/* open time (for FD caching) */
+	time_t		ti_mod ;	/* last modification time */
+	time_t		ti_check ;	/* last check time */
+	size_t		mapsize ;
+	size_t		fsize ;		/* file total size */
+	TMPX_FL		f ;
+	uint		mapoff ;	/* file mapping starting offset */
+	uint		magic ;
+	int		pagesize ;
+	int		oflags ;	/* open flags */
+	int		operms ;	/* open permissions */
+	int		fd ;		/* file descriptor */
+	int		ncursors ;
+	int		mapei ;		/* index of top mapped entry */
+	int		mapen ;		/* number of mapped entries */
+} ;
+
+typedef TMPX		tmpx ;
+typedef TMPX_CUR	tmpx_cur ;
+typedef TMPX_ENT	tmpx_ent ;
+
+EXTERNC_begin
+
+extern int tmpx_open(tmpx *,cchar *,int) noex ;
+extern int tmpx_read(tmpx *,int,tmpx_ent *) noex ;
+extern int tmpx_write(tmpx *,int,tmpx_ent *) noex ;
+extern int tmpx_check(tmpx *,time_t) noex ;
+extern int tmpx_curbegin(tmpx *,tmpx_cur *) noex ;
+extern int tmpx_curend(tmpx *,tmpx_cur *) noex ;
+extern int tmpx_enum(tmpx *,tmpx_cur *,tmpx_ent *) noex ;
+extern int tmpx_fetchuser(tmpx *,tmpx_cur *,tmpx_ent *,cchar *) noex ;
+extern int tmpx_fetchpid(tmpx *,tmpx_ent *,pid_t) noex ;
+extern int tmpx_nusers(tmpx *) noex ;
+extern int tmpx_close(tmpx *) noex ;
+
+EXTERNC_end
+
+
+#endif /* TMPX_INCLUDE */
+
+

--- a/include/utmpacc.h
+++ b/include/utmpacc.h
@@ -1,0 +1,126 @@
+/* utmpacc HEADER */
+/* lang=C20 */
+
+/* UTMPACC management */
+/* version %I% last-modified %G% */
+
+
+/* revision history:
+
+	= 1998-02-01, David A­D­ Morano
+	This subroutine was originally written.
+
+*/
+
+/* Copyright © 1998 David A­D­ Morano.  All rights reserved. */
+
+/*******************************************************************************
+
+	This module serves as a per-process cache for UNIX® UTMP
+	information.
+
+	Since we are basically dealing with global data, we need
+	to make the establishment of it multi-thread safe.  We also
+	want fork safety.  Yes, we want everything, including cleanup
+	on module unloading (since, yes, we could all be inside a
+	loadable and unloadble module!).  For these purposes we
+	employ the basic (and not so basic) means of accomplishing
+	this.  See the code for our various machinations.
+
+*******************************************************************************/
+
+#ifndef	UTMPACC_INCLUDE
+#define	UTMPACC_INCLUDE
+
+
+#include	<envstandards.h>	/* MUST be first to configure */
+#include	<sys/types.h>
+#include	<utmpx.h>
+#include	<utypedefs.h>
+#include	<utypealiases.h>
+#include	<clanguage.h>
+#include	<localmisc.h>
+#include	<utmpaccent.h>		/* <- the money shot */
+
+
+#define	UTMPACC_ENT	UTMPACCENT
+#define	UTMPACC_SB	struct utmpacc_statistics
+#define	UTMPACC_CUR	struct utmpacc_cursor
+
+#define	UTMPACC_BUFLEN	332		/* large enough for all fields */
+#define	UTMPACC_MAX	20
+#define	UTMPACC_TTL	(20*60)
+
+#if	(defined(OSNAME_SunOS) && (OSNAME_SunOS > 0))
+#define	UTMPACC_DEFUTMP	"/var/adm/utmpx"
+#elif	(defined(OSNAME_Darwin) && (OSNAME_Darwin > 0))
+#define	UTMPACC_DEFUTMP	"/var/run/utmpx"
+#else
+#define	UTMPACC_DEFUTMP	"/var/run/utmpx"
+#endif
+
+#ifndef	UTMPACC_TEMPTY
+#define	UTMPACC_TEMPTY		0	/* entry is unused */
+#define	UTMPACC_TRUNLEVEL	1
+#define	UTMPACC_TBOOTTIME	2
+#define	UTMPACC_TOLDTIME	3
+#define	UTMPACC_TNEWTIME	4
+#define	UTMPACC_TPROCINIT	5	/* process spawned by "init" */
+#define	UTMPACC_TPROCLOGIN	6	/* a "getty" waiting for login */
+#define	UTMPACC_TPROCUSER	7	/* a regular user process */
+#define	UTMPACC_TPROCDEAD	8	/* used in WTMPX only? */
+#define	UTMPACC_TACCOUNT	9	/* used in WTMPX only? */
+#define	UTMPACC_TSIGNATURE	10	/* used in WTMPX only? */
+#endif /* UTMPACC_TEMPTY */
+
+#ifndef	UTMPACC_LID
+#define	UTMPACC_LID		4
+#define	UTMPACC_LUSER		32
+#define	UTMPACC_LLINE		32
+#define	UTMPACC_LHOST		256
+#endif
+
+
+enum utxproctypes {
+	utxproctype_user,
+	utxproctype_login,
+	utxproctype_init,
+	utxproctype_dead,
+	utxproctype_overlast
+} ;
+
+struct utmpacc_statistics {
+	uint		maxusers ;
+	uint		maxents ;
+} ;
+
+struct utmpacc_cursor {
+	void		*icursor ;
+} ;
+
+typedef	UTMPACC_SB	utmpacc_sb ;
+typedef	UTMPACC_CUR	utmpacc_cur ;
+typedef	UTMPACC_ENT	utmpacc_ent ;
+
+EXTERNC_begin
+
+extern int utmpacc_init() noex ;
+extern int utmpacc_boottime(time_t *) noex ;
+extern int utmpacc_runlevel() noex ;
+extern int utmpacc_users(int) noex ;
+extern int utmpacc_entsid(utmpacc_ent *,char *,int,pid_t) noex ;
+extern int utmpacc_entline(utmpacc_ent *,char *,int,cchar *,int) noex ;
+extern int utmpacc_stats(utmpacc_sb *) noex ;
+extern int utmpacc_extract(int) noex ;
+extern int utmpacc_fini() noex ;
+
+extern int utmpacc_curbegin(utmpacc_cur *) noex ;
+extern int utmpacc_curenum(utmpacc_cur *,utmpacc_ent *,char *,int) noex ;
+extern int utmpacc_curend(utmpacc_cur *) noex ;
+
+EXTERNC_end
+
+
+#endif /* UTMPACC_INCLUDE */
+
+

--- a/include/utmpaccent.h
+++ b/include/utmpaccent.h
@@ -75,11 +75,12 @@ struct utmpaccent_s {
 } ; /* end struct (utmpaccent) */
 
 typedef UTMPACCENT	utmpaccent ;
+typedef CUTMPACCENT	cutmpaccent ;
 
 EXTERNC_begin
 
-extern int utmpaccent_load(UTMPACCENT *,char *,int,CUTMPFENT *) noex ;
-extern int utmpaccent_size(CUTMPACCENT *) noex ;
+extern int utmpaccent_load(utmpaccent *,char *,int,CUTMPFENT *) noex ;
+extern int utmpaccent_size(cutmpaccent *) noex ;
 
 EXTERNC_end
 

--- a/src/libuc/envhelp.cc
+++ b/src/libuc/envhelp.cc
@@ -49,11 +49,7 @@
 *******************************************************************************/
 
 #include	<envstandards.h>	/* MUST be first to configure */
-#include	<sys/types.h>
-#include	<sys/param.h>
-#include	<unistd.h>
-#include	<cstdlib>
-#include	<cstring>
+#include	<cstring>		/* <- for |strlen(3c)| */
 #include	<usystem.h>
 #include	<nulstr.h>
 #include	<strwcpy.h>

--- a/src/libuc/envlist.cc
+++ b/src/libuc/envlist.cc
@@ -22,10 +22,8 @@
 *******************************************************************************/
 
 #include	<envstandards.h>	/* MUST be first to configure */
-#include	<cstdlib>
 #include	<cstring>		/* <- for |strlen(3c)| */
 #include	<usystem.h>
-#include	<usupport.h>		/* <- for |memclear(3uc)| */
 #include	<strpack.h>
 #include	<strn.h>
 #include	<strwcpy.h>
@@ -113,7 +111,6 @@ static int	envlist_storer(envlist *) noex ;
 int envlist_start(envlist *op,int ne) noex {
 	int		rs = SR_FAULT ;
 	if ((rs = envlist_ctor(op)) >= 0) {
-	    memclear(op) ;
 	    rs = ENVLIST_DBINIT(op->elp,ne,0,nullptr,nullptr) ;
 	    if (rs < 0) {
 		envlist_dtor(op) ;

--- a/src/libuc/getutmpent.cc
+++ b/src/libuc/getutmpent.cc
@@ -4,10 +4,6 @@
 /* get user information from UTMP database */
 /* version %I% last-modified %G% */
 
-#define	CF_TMPX		0		/* try TMPX */
-#define	CF_UTMPX	1		/* try UTMPX (otherwise UTMP) */
-#define	CF_FETCHPID	1		/* use 'fetchpid()' where possible */
-#define	CF_UTMPACC	1		/* use |ugetutmpacc()| */
 
 /* revision history:
 
@@ -40,7 +36,7 @@
 
 	Returns:
 	>=0		length of user buf
-	<0		error
+	<0		error (system-return)
 
 *******************************************************************************/
 
@@ -50,18 +46,8 @@
 #include	<unistd.h>
 #include	<cstdlib>
 #include	<cstring>
-#include	<utmp.h>
-
-#if	CF_UTMPX && defined(SYSHAS_UTMPX) && (SYSHAS_UTMPX > 0)
-#include	<utmpx.h>
-#endif
-
+#include	<algorithm>		/* <- for |min(3c++)| */
 #include	<usystem.h>
-
-#if	CF_TMPX || CF_UTMPX
-#include	<tmpx.h>
-#endif
-
 #include	<utmpacc.h>
 #include	<strwcpy.h>
 #include	<sncpyx.h>
@@ -74,9 +60,13 @@
 
 #define	AEBUFLEN	sizeof(struct utmpx)
 
-#ifndef	CF_FETCHPID
-#define	CF_FETCHPID	0		/* default safety */
-#endif
+
+/* local namespaces */
+
+using std::min ;			/* subroutine-template */
+
+
+/* local typedefs */
 
 
 /* external subroutines */
@@ -91,57 +81,29 @@
 /* forward references */
 
 static int getutmpent_utmpacc(GETUTMPENT *,pid_t) noex ;
-static int getutmpent_tmpx(GETUTMPENT *,pid_t) noex ;
-static int getutmpent_utmpx(GETUTMPENT *,pid_t) noex ;
-static int getutmpent_utmp(GETUTMPENT *,pid_t) noex ;
 
 
 /* local variables */
 
-constexpr bool		f_fetchpid = CF_FETCHPID ;
+
+/* exported variables */
+
 
 /* exported subroutines */
 
 int getutmpent(GETUTMPENT *ep,pid_t sid) noex {
-	int		rs = SR_NOTFOUND ;
-
-	if (ep == nullptr) return SR_FAULT ;
-
-	ep->id[0] = '\0' ;
-	ep->line[0] = '\0' ;
-	ep->user[0] = '\0' ;
-	ep->host[0] = '\0' ;
-	ep->session = 0 ;
-	ep->date = 0 ;
-
-	if (sid <= 0) sid = getsid(0) ;
-
-	ep->sid = sid ;
-
-/* do the DB search */
-
-#if	CF_UTMPACC
-	if (rs == SR_NOTFOUND) {
+	int		rs = SR_FAULT ;
+	if (ep) {
+	    ep->id[0] = '\0' ;
+	    ep->line[0] = '\0' ;
+	    ep->user[0] = '\0' ;
+	    ep->host[0] = '\0' ;
+	    ep->session = 0 ;
+	    ep->date = 0 ;
+	    if (sid <= 0) sid = getsid(0) ;
+	    ep->sid = sid ;
 	    rs = getutmpent_utmpacc(ep,sid) ;
-	}
-#else /* CF_UTMPACC */
-#if	CF_TMPX
-	if (rs == SR_NOTFOUND) {
-	    rs = getutmpent_tmpx(ep,sid) ;
-	}
-#else /* CF_TMPX */
-#if	CF_UTMPX && defined(SYSHAS_UTMPX) && (SYSHAS_UTMPX > 0)
-	if (rs == SR_NOTFOUND) {
-	    rs = getutmpent_utmpx(ep,sid) ;
-	}
-#else /* CF_UTMPX */
-	if (rs == SR_NOTFOUND) {
-	    rs = getutmpent_utmp(ep,sid) ;
-	}
-#endif /* CF_UTMPX */
-#endif /* CF_TMPX */
-#endif /* CF_UTMPACC */
-
+	} /* end if (non-null) */
 	return rs ;
 }
 /* end subroutine (getutmpent) */
@@ -149,7 +111,7 @@ int getutmpent(GETUTMPENT *ep,pid_t sid) noex {
 int getutmpname(char *rbuf,int rlen,pid_t sid) noex {
 	int		rs = SR_FAULT ;
 	if (rbuf) {
-	    GETUTMPENT	e ;
+	    GETUTMPENT	e{} ;
 	    if (rlen < 0) rlen = GETUTMPENT_LUSER ;
 	    rbuf[0] = '\0' ;
 	    if ((rs = getutmpent(&e,sid)) >= 0) {
@@ -163,7 +125,7 @@ int getutmpname(char *rbuf,int rlen,pid_t sid) noex {
 int getutmphost(char *rbuf,int rlen,pid_t sid) noex {
 	int		rs = SR_FAULT ;
 	if (rbuf) {
-	    GETUTMPENT	e ;
+	    GETUTMPENT	e{} ;
 	    if (rlen < 0) rlen = GETUTMPENT_LHOST ;
 	    rbuf[0] = '\0' ;
 	    if ((rs = getutmpent(&e,sid)) >= 0) {
@@ -177,7 +139,7 @@ int getutmphost(char *rbuf,int rlen,pid_t sid) noex {
 int getutmpline(char *rbuf,int rlen,pid_t sid) noex {
 	int		rs = SR_FAULT ;
 	if (rbuf) {
-	    GETUTMPENT	e ;
+	    GETUTMPENT	e{} ;
 	    if (rlen < 0) rlen = GETUTMPENT_LLINE ;
 	    rbuf[0] = '\0' ;
 	    if ((rs = getutmpent(&e,sid)) >= 0) {
@@ -191,17 +153,16 @@ int getutmpline(char *rbuf,int rlen,pid_t sid) noex {
 
 /* local subroutines */
 
-#if	CF_UTMPACC
 static int getutmpent_utmpacc(GETUTMPENT *ep,pid_t sid) noex {
-	UTMPACC_ENT	ae ;
-	const int	aelen = AEBUFLEN ;
+	UTMPACC_ENT	ae{} ;
+	cint		aelen = AEBUFLEN ;
 	int		rs ;
 	char		aebuf[AEBUFLEN+1] ;
 	if ((rs = utmpacc_entsid(&ae,aebuf,aelen,sid)) >= 0) {
-	    strwcpy(ep->id,ae.id,MIN(GETUTMPENT_LID,TMPX_LID)) ;
-	    strwcpy(ep->user,ae.user,MIN(GETUTMPENT_LUSER,TMPX_LUSER)) ;
-	    strwcpy(ep->line,ae.line,MIN(GETUTMPENT_LLINE,TMPX_LLINE)) ;
-	    strwcpy(ep->host,ae.host,MIN(GETUTMPENT_LHOST,TMPX_LHOST)) ;
+	    strwcpy(ep->id,ae.id,min(GETUTMPENT_LID,UTMPACC_LID)) ;
+	    strwcpy(ep->user,ae.user,min(GETUTMPENT_LUSER,UTMPACC_LUSER)) ;
+	    strwcpy(ep->line,ae.line,min(GETUTMPENT_LLINE,UTMPACC_LLINE)) ;
+	    strwcpy(ep->host,ae.host,min(GETUTMPENT_LHOST,UTMPACC_LHOST)) ;
 	    ep->session = ae.session ;
 	    ep->date = ae.ctime ;
 	    ep->sid = ae.sid ;
@@ -209,104 +170,5 @@ static int getutmpent_utmpacc(GETUTMPENT *ep,pid_t sid) noex {
 	return rs ;
 }
 /* end subroutine (getutmpent_utmpacc) */
-#else /* CF_UTMPACC */
-#if	CF_TMPX
-
-static int getutmpent_tmpx(GETUTMPENT *ep,pid_t sid) noex {
-	TMPX		db ;
-	TMPX_ENT	e ;
-	int		rs ;
-	int		c = 0 ;
-	if ((rs = tmpx_open(&db,nullptr,O_RDONLY)) >= 0) {
-	    if constexpr (f_fetchpid) {
-	         rs = tmpx_fetchpid(&db,&e,sid) ;
-	         c = rs ;
-	    } else {
-	        TMPX_CUR	cur ;
-	        if ((rs = tmpx_curbegin(&db,&cur)) >= 0) {
-	            while ((rs = tmpx_enum(&db,&cur,&e)) >= 0) {
-			bool	f = (e.ut_type == TMPX_TUSERPROC) ;
-			f = f && (e.ut_pid == sid) ;
-			if (f) break ;
-	                c += 1 ;
-	            } /* end while */
-	            tmpx_curend(&db,&cur) ;
-	        } /* end if (cursor) */
-	    } /* end if-constexpr (f_fetchpid) */
-	    if (rs >= 0) {
-	        strwcpy(ep->id,e.ut_id,MIN(GETUTMPENT_LID,TMPX_LID)) ;
-	        strwcpy(ep->line,e.ut_line,MIN(GETUTMPENT_LLINE,TMPX_LLINE)) ;
-	        strwcpy(ep->user,e.ut_user,MIN(GETUTMPENT_LUSER,TMPX_LUSER)) ;
-	        strwcpy(ep->host,e.ut_host,MIN(GETUTMPENT_LHOST,TMPX_LHOST)) ;
-	        ep->session = e.ut_session ;
-	        ep->date = e.ut_tv.tv_sec ;
-	    } /* end if (opened the TMPX DB) */
-	    tmpx_close(&db) ;
-	} /* end if (opened TMPX DB) */
-	return (rs >= 0) ? c : rs ;
-}
-/* end subroutine (getutmpent_tmpx) */
-
-#endif /* CF_TMPX */
-
-#if	CF_UTMPX && defined(SYSHAS_UTMPX) && (SYSHAS_UTMPX > 0)
-
-static int getutmpent_utmpx(GETUTMPENT *ep,pid_t sid) noex {
-	struct utmpx	*up ;
-	int		rs = SR_NOTFOUND ;
-	int		c = 0 ;
-	setutxent() ;
-	while ((up = getutxent()) != nullptr) {
-	    if ((up->ut_type == UTMPX_TUSERPROC) &&
-	        (up->ut_pid == sid)) {
-	        rs = SR_OK ;
-	        break ;
-	    }
-	    c += 1 ;
-	} /* end while */
-	if (rs >= 0) {
-	    strwcpy(ep->id,up->ut_id,MIN(GETUTMPENT_LID,UTMPX_LID)) ;
-	    strwcpy(ep->line,up->ut_line,MIN(GETUTMPENT_LLINE,UTMPX_LLINE)) ;
-	    strwcpy(ep->user,up->ut_user,MIN(GETUTMPENT_LUSER,UTMPX_LUSER)) ;
-	    strwcpy(ep->host,up->ut_host,MIN(GETUTMPENT_LHOST,UTMPX_LHOST)) ;
-	    ep->session = up->ut_session ;
-	    ep->date = up->ut_tv.tv_sec ;
-	} /* end if */
-	endutxent() ;
-	return (rs >= 0) ? c : rs ;
-}
-/* end subroutine (getutmpent_utmpx) */
-
-#else /* CF_UTMPX */
-
-static int getutmpent_utmp(GETUTMPENT *ep,pid_t sid) noex {
-	struct utmp	*up ;
-	int		rs = SR_NOTFOUND ;
-	int		c = 0 ;
-	setutent() ;
-	while ((up = getutent()) != nullptr) {
-	    if ((up->ut_type == UTMP_TUSERPROC) &&
-	        (up->ut_pid == sid)) {
-	        rs = SR_OK ;
-	        break ;
-	    }
-	    c += 1 ;
-	} /* end while */
-	if (rs >= 0) {
-	    strwcpy(ep->id,up->ut_id,MIN(GETUTMPENT_LID,UTMP_LID)) ;
-	    strwcpy(ep->line,up->ut_line,MIN(GETUTMPENT_LLINE,UTMP_LLINE)) ;
-	    strwcpy(ep->user,up->ut_user,MIN(GETUTMPENT_LUSER,UTMP_LUSER)) ;
-#ifdef	COMMENT /* does not exist! */
-	    strwcpy(ep->host,up->ut_host,MIN(GETUTMPENT_LHOST,UTMPX_LHOST)) ;
-#endif
-	    ep->date = e.ut_time ;
-	} /* end if */
-	endutent() ;
-	return (rs >= 0) ? c : rs ;
-}
-/* end subroutine (getutmpent_utmp) */
-
-#endif /* CF_UTMPX */
-#endif /* CF_UTMPACC */
 
 

--- a/src/libuc/utmpacc.cc
+++ b/src/libuc/utmpacc.cc
@@ -301,6 +301,7 @@ int utmpacc::iinit() noex {
 	int		f = false ;
 	if (! fvoid) {
 	    cint	to = utimeout[uto_busy] ;
+	    rs = SR_OK ;
 	    if (! finit.testandset) {
 	        if ((rs = mx.create) >= 0) {
 	            if ((rs = cv.create) >= 0) {
@@ -311,17 +312,21 @@ int utmpacc::iinit() noex {
 	                        f = true ;
 	                        finitdone = true ;
 	                    }
-	                    if (rs < 0)
+	                    if (rs < 0) {
 	                        uc_atforkexpunge(b,a,a) ;
+			    }
 	                } /* end if (uc_atfork) */
-	                if (rs < 0)
+	                if (rs < 0) {
 	                    cv.destroy() ;
+			}
 	            } /* end if (ptc_create) */
-	            if (rs < 0)
+	            if (rs < 0) {
 	                mx.destroy() ;
+		    }
 	        } /* end if (ptm_create) */
-	        if (rs < 0)
+	        if (rs < 0) {
 	            finit = false ;
+		}
 	    } else if (!finitdone) {
 	        timewatch	tw(to) ;
 	        auto lamb = [this] () -> int {

--- a/src/libuc/utmpacc.h
+++ b/src/libuc/utmpacc.h
@@ -14,6 +14,21 @@
 
 /* Copyright © 1998 David A­D­ Morano.  All rights reserved. */
 
+/*******************************************************************************
+
+	This module serves as a per-process cache for UNIX® UTMP
+	information.
+
+	Since we are basically dealing with global data, we need
+	to make the establishment of it multi-thread safe.  We also
+	want fork safety.  Yes, we want everything, including cleanup
+	on module unloading (since, yes, we could all be inside a
+	loadable and unloadble module!).  For these purposes we
+	employ the basic (and not so basic) means of accomplishing
+	this.  See the code for our various machinations.
+
+*******************************************************************************/
+
 #ifndef	UTMPACC_INCLUDE
 #define	UTMPACC_INCLUDE
 

--- a/src/libuc/utmpaccent.h
+++ b/src/libuc/utmpaccent.h
@@ -75,11 +75,12 @@ struct utmpaccent_s {
 } ; /* end struct (utmpaccent) */
 
 typedef UTMPACCENT	utmpaccent ;
+typedef CUTMPACCENT	cutmpaccent ;
 
 EXTERNC_begin
 
-extern int utmpaccent_load(UTMPACCENT *,char *,int,CUTMPFENT *) noex ;
-extern int utmpaccent_size(CUTMPACCENT *) noex ;
+extern int utmpaccent_load(utmpaccent *,char *,int,CUTMPFENT *) noex ;
+extern int utmpaccent_size(cutmpaccent *) noex ;
 
 EXTERNC_end
 

--- a/src/libuc/utmpent.cc
+++ b/src/libuc/utmpent.cc
@@ -16,7 +16,7 @@
 
 /*******************************************************************************
 
-        This code provides the methods for the utmpent object.
+        This code provides the methods for the UTMPENT object.
 
 *******************************************************************************/
 

--- a/src/macuser/username.fun
+++ b/src/macuser/username.fun
@@ -1,0 +1,11 @@
+# USERNAME (shell function)
+
+function username {
+  : ${USERNAME:=${LOGNAME}}
+  : ${USERNAME:=${USER}}
+  : ${USERNAME:=${HOME##*/}}
+  : ${USERNAME:=${MAIL##*/}}
+  print -- ${USERNAME}
+}
+
+


### PR DESCRIPTION
refactored |getutmpent| to only use |utmpacc| rather than the four or five alternatives that were originally coded
